### PR TITLE
Add `logseq-mochi-sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of open-source integrations with Mochi
 - [mochi2anki](https://github.com/AlexW00/mochi2anki) Simple converter script to convert Mochi cards to Anki cards.
 - [mochi-api-client](https://github.com/gsejas/mochi-api-client) Python wrapper for the Mochi spaced repetition platform
 - [ug-to-mochi.py](https://gist.github.com/intellectronica/f5d093ccb1618aa3f9faf6d5c42304f3) (Script for creating Mochi flashcards based on the Ultimate Geography card collection)
+- [logseq-mochi-sync](https://github.com/benwr/logseq-mochi-sync) Sync flash cards from Logseq to Mochi.
 
 ## Contributing
 If you have an open source project you'd like to share, please submit a pull request!


### PR DESCRIPTION
I wrote a plugin for syncing flashcards from Logseq to Mochi. It's currently being reviewed for inclusion in the Logseq Marketplace.